### PR TITLE
Tweak Workflows

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
   pull_request:
-    branches-ignore: [ main ]
     types: [ opened ]
     paths: [ src/** ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
 
   pull_request:
     types: [ opened, synchronize ]
+    paths: [ src/** ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
         with:
           ref: ${{ github.ref }}
           workflow: ci.yaml


### PR DESCRIPTION
* bump_version.yaml: doesn't need the `branches-ignore` key since it'll only be on PRs which by policy must not be `main`.
* ci.yaml: should make sure to only run this on `src/` changes too.
* release.yaml: missed pinning `download-artifact`