### PR TITLE
Include CI in release.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,12 @@ name: Validate Code Changes
 on:
   workflow_dispatch:
 
+  workflow_call:
+    outputs:
+      run_id:
+        description: Used to get artifacts from this run.
+        value: ${{ github.run_id }}
+
   pull_request:
     types: [ opened, synchronize ]
     paths: [ src/** ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,11 +21,24 @@ permissions:
   contents: write
 
 jobs:
+  build:
+    name: CI Sanity Check
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+
+    runs-on: windows-latest
+
+    steps:
+      - name: Final CI Check
+        id: ci
+        uses: ./.github/workflows/ci.yaml
+
+    outputs:
+      run_id: ${{ steps.ci.outputs.run_id }}
+
   create_tag:
     name: Create Tag
-    if: |
-      github.event.pull_request.merged == true
-      || github.event_name == 'workflow_dispatch'
+    needs: [ build ]
+    if: needs.build.result == 'success'
 
     runs-on: ubuntu-latest
 
@@ -55,8 +68,8 @@ jobs:
 
   release:
     name: Create Release with Artifacts
-    if: ${{ success() }}
-    needs: [ create_tag ]
+    needs: [ build, create_tag ]
+    if: needs.create_tag.result == 'success'
 
     runs-on: ubuntu-latest
 
@@ -68,9 +81,8 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
         with:
-          ref: ${{ github.head_ref || github.ref }}
           workflow: ci.yaml
-          workflow_search: true
+          run_id: ${{ needs.build.outputs.run_id }}
 
       - name: Zip Artifacts
         run: zip -r ${REPO_NAME}.zip . -x *.sigstore.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ on:
 
   pull_request:
     types: [ closed ]
+    paths: [ src/** ]
 
 permissions:
   contents: write


### PR DESCRIPTION
Having some difficulty with the artifact searching action. I don't see the harm in running CI again on merge to ensure it is safe to create a tag and release. This has the added benefit of knowing precisely where the artifact comes from. This also ensures no failure when a PR doesn't modify `src/`.