### PR TITLE
Identify Breaking Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ This project demonstrates a variety of important industry standards and techniqu
 ## Python:
 - Packaging
 - MVC Design Pattern
-- Cross Platform Design
 - Threading
 - Calling RESTful APIs
   - Online Version Update Checking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gw2-addon-manager"
 description = "A simple tool to manage addons for Guild Wars 2."
-version = "1.1.0"
+version = "2.0.0"
 
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "gw2-addon-manager"
-version = "1.1.0"
+version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pywin32" },


### PR DESCRIPTION
Due to the pywin32 dependency the application is not currently cross platform and must be noted as a breaking change.